### PR TITLE
Error msg in signin

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -55,6 +55,7 @@ router.post(
     failureFlash: true,
   })
 );
+//Jennifer: add codes on showing msg to user when signin is unsuccessful.
 
 /* User Sign-Up Request. */
 router.post("/signup", async (req, res) => {


### PR DESCRIPTION
I like your codes on signin to redirect user to different page based on authentication status. I saw you write message info about unsuccessful signin in passport-config.js file, but the message is never used. It would be nice to show the msg out when the user signin unsuccess.